### PR TITLE
Feature update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+*.env
+
 # compiled output
 /dist
 /node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 *.env
-
 # compiled output
 /dist
 /node_modules

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,6 +1,5 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { DataSource } from 'typeorm';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { BlogModule } from './blog/blog.module';

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { DataSource } from 'typeorm';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { BlogModule } from './blog/blog.module';
@@ -21,4 +22,6 @@ import { BlogModule } from './blog/blog.module';
   controllers: [AppController],
   providers: [AppService],
 })
-export class AppModule {}
+export class AppModule {
+  constructor(private dataSource: DataSource) {}
+}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -22,6 +22,4 @@ import { BlogModule } from './blog/blog.module';
   controllers: [AppController],
   providers: [AppService],
 })
-export class AppModule {
-  constructor(private dataSource: DataSource) {}
-}
+export class AppModule {}

--- a/src/blog/blog.controller.ts
+++ b/src/blog/blog.controller.ts
@@ -8,7 +8,7 @@ import {
   Res,
 } from '@nestjs/common';
 import { BlogService } from './blog.service';
-import { CreateBoardDTO, CreateBoardResponse } from './dto/create-Board.dto';
+import { CreateBoardDto, CreateBoardResponse } from './dto/create-board.dto';
 import { Board } from './entity/board.entity';
 
 @Controller('blog')
@@ -18,7 +18,7 @@ export class BlogController {
   // submit a post
   @Post('/post')
   async createBoard(
-    @Body() createBoardDto: CreateBoardDTO,
+    @Body() createBoardDto: CreateBoardDto,
   ): Promise<CreateBoardResponse> {
     try {
       const newBoard = await this.boardService.createBoard(createBoardDto);

--- a/src/blog/blog.controller.ts
+++ b/src/blog/blog.controller.ts
@@ -4,11 +4,13 @@ import {
   Controller,
   HttpStatus,
   InternalServerErrorException,
+  Param,
   Post,
   Res,
 } from '@nestjs/common';
 import { BlogService } from './blog.service';
 import { CreateBoardDto, CreateBoardResponse } from './dto/create-board.dto';
+import { UpdateBoardDto } from './dto/update-board.dto';
 import { Board } from './entity/board.entity';
 
 @Controller('blog')
@@ -39,5 +41,13 @@ export class BlogController {
           );
       }
     }
+  }
+
+  @Post('/:id')
+  async updateBoard(
+    @Param('id') id: string,
+    @Body() updateBoardDto: UpdateBoardDto,
+  ) {
+    return this.boardService.updateBoard(id, updateBoardDto);
   }
 }

--- a/src/blog/blog.controller.ts
+++ b/src/blog/blog.controller.ts
@@ -48,6 +48,6 @@ export class BlogController {
     @Param('id') id: string,
     @Body() updateBoardDto: UpdateBoardDto,
   ) {
-    return this.boardService.updateBoard(id, updateBoardDto);
+    return await this.boardService.updateBoard(id, updateBoardDto);
   }
 }

--- a/src/blog/blog.service.ts
+++ b/src/blog/blog.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { CreateBoardDTO } from './dto/create-Board.dto';
+import { CreateBoardDto } from './dto/create-board.dto';
 import { Board } from './entity/board.entity';
 
 @Injectable()
@@ -15,7 +15,7 @@ export class BlogService {
     return this.boardRepository.find();
   }
 
-  createBoard(creatBoardDto: CreateBoardDTO): Promise<Board> {
+  createBoard(creatBoardDto: CreateBoardDto): Promise<Board> {
     try {
       const newBoard = this.boardRepository.create(creatBoardDto);
       return this.boardRepository.save(newBoard);

--- a/src/blog/blog.service.ts
+++ b/src/blog/blog.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { CreateBoardDto } from './dto/create-board.dto';
+import { UpdateBoardDto } from './dto/update-board.dto';
 import { Board } from './entity/board.entity';
 
 @Injectable()
@@ -22,5 +23,19 @@ export class BlogService {
     } catch (e) {
       throw e;
     }
+  }
+
+  updateBoard(id: string, updateBoardDto: UpdateBoardDto) {
+    return this.boardRepository.update(
+      {
+        id,
+      },
+      {
+        title: updateBoardDto.title,
+        author: updateBoardDto.author,
+        body: updateBoardDto.body,
+        description: updateBoardDto.description,
+      },
+    );
   }
 }

--- a/src/blog/blog.service.ts
+++ b/src/blog/blog.service.ts
@@ -1,6 +1,7 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { NotFoundError } from 'rxjs';
+import { Repository, UpdateResult } from 'typeorm';
 import { CreateBoardDto } from './dto/create-board.dto';
 import { UpdateBoardDto } from './dto/update-board.dto';
 import { Board } from './entity/board.entity';
@@ -25,17 +26,34 @@ export class BlogService {
     }
   }
 
-  updateBoard(id: string, updateBoardDto: UpdateBoardDto) {
-    return this.boardRepository.update(
-      {
-        id,
-      },
-      {
-        title: updateBoardDto.title,
-        author: updateBoardDto.author,
-        body: updateBoardDto.body,
-        description: updateBoardDto.description,
-      },
-    );
+  async updateBoard(
+    id: string,
+    updateBoardDto: UpdateBoardDto,
+  ): Promise<UpdateResult> {
+    try {
+      const board = await this.boardRepository.findOne({
+        where: {
+          id,
+        },
+      });
+      if (board) {
+        return this.boardRepository.update(
+          {
+            id,
+          },
+          {
+            title: updateBoardDto.title,
+            author: updateBoardDto.author,
+            body: updateBoardDto.body,
+            description: updateBoardDto.description,
+          },
+        );
+      }
+      throw new NotFoundException(
+        'Reject update request since it is not available ID',
+      );
+    } catch (e) {
+      throw e;
+    }
   }
 }

--- a/src/blog/dto/update-board.dto.ts
+++ b/src/blog/dto/update-board.dto.ts
@@ -1,4 +1,4 @@
-export class CreateBoardDto {
+export class UpdateBoardDto {
   readonly title: string;
 
   readonly description: string;
@@ -6,8 +6,4 @@ export class CreateBoardDto {
   readonly body: string;
 
   readonly author: string;
-}
-
-export class CreateBoardResponse {
-  id: string;
 }

--- a/src/board.repository.ts
+++ b/src/board.repository.ts
@@ -1,0 +1,9 @@
+import { CreateBoardDto } from './blog/dto/create-board.dto';
+import { Board } from './blog/entity/board.entity';
+import { AppdataSource } from './datasource';
+
+const dataSource = AppdataSource;
+
+export const boardRepository = dataSource.getRepository(Board).extend({
+  // content
+});

--- a/src/board.repository.ts
+++ b/src/board.repository.ts
@@ -1,9 +1,0 @@
-import { CreateBoardDto } from './blog/dto/create-board.dto';
-import { Board } from './blog/entity/board.entity';
-import { AppdataSource } from './datasource';
-
-const dataSource = AppdataSource;
-
-export const boardRepository = dataSource.getRepository(Board).extend({
-  // content
-});


### PR DESCRIPTION
Board CRUD api 중 UPDATE를 구현하였습니다.
# As is
기존에는 **UPDATE**하는 기능이 구현되어있지 않았습니다.

# To be
`POST blog/:id` (id 형식: uuid) endpoint로 모든 Board를 가져올 수 있습니다

---

* 해당 파일에서 CreateDTO → CreateDto 로 이름을 수정해서 해당 브랜치와 관계없는 수정이 커밋되었습니다.
* 이름 수정을 커밋 2번에 나누어서 해서 이 부분은 Revert로 건드니까 파일이 꼬입니다. 그냥 관련 파일은 그대로 두는 것이 좋을 것 같습니다.